### PR TITLE
Create remote events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -75,7 +75,7 @@ before_action :set_event, only: [:show]
     params.require(:event).permit(:name, :description,
                                   :start_time, :duration,
                                   :private, :open_invite,
-                                  :room_id, :user_id, :agenda )
+                                  :room_id, :user_id, :agenda, :allow_remote )
   end
 
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -50,4 +50,16 @@ class Event < ActiveRecord::Base
   def good_time_range?
     room.event_overlap?(self)
   end
+
+  def get_physical_participation
+    invites.where(status: "Accepted").count
+  end
+
+  def get_remote_participation
+    invites.where(status: "Accepted[remote]").count
+  end
+
+  def get_total_participation
+    invites.where(status: "Accepted").count + invites.where(status:"Accepted[remote]").count
+  end
 end

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -1,6 +1,6 @@
 class Invite < ActiveRecord::Base
   def self.confirmation
-    ['Accepted', 'Rejected', 'Pending']
+    ['Accepted', 'Rejected', 'Pending', 'Accepted[remote]']
   end
 
   belongs_to :user

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -1,3 +1,11 @@
+class RemoteInvite < ActiveModel::Validator
+  def validate(record)
+    if record.status == "Accepted[remote]" && record.event.allow_remote
+      record.errors[:base] << 'This event does not allow remote attendance!'
+    end
+  end
+end
+
 class Invite < ActiveRecord::Base
   def self.confirmation
     ['Accepted', 'Rejected', 'Pending', 'Accepted[remote]']
@@ -5,7 +13,7 @@ class Invite < ActiveRecord::Base
 
   belongs_to :user
   belongs_to :event
-
+  validates_with RemoteInvite
   validates :user_id, presence: { message: "Invalid User Name" }
   validates :user_id, uniqueness: {
     scope: :event_id,

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -21,6 +21,9 @@
       <%= f.label :agenda %><br>
       <%= f.text_field :agenda, class: "form-control" %><br>
 
+      <%= f.label :allow_remote, "Allow remote attendance?" %>
+      <%= f.check_box :allow_remote %>
+
       <%= f.submit "Submit", class: "btn btn-default btn-primary" %>
   <% end %>
 </div>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -22,7 +22,7 @@
       <%= f.text_field :agenda, class: "form-control" %><br>
 
       <%= f.label :allow_remote, "Allow remote attendance?" %>
-      <%= f.check_box :allow_remote %>
+      <%= f.check_box :allow_remote %><br>
 
       <%= f.submit "Submit", class: "btn btn-default btn-primary" %>
   <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -13,6 +13,8 @@
     <% if @event.is_private? %>
       <p><strong>Invite Type:</strong> <%= @event.invite_type %>
     <% end %>
+    <p><strong> Allow Remote Attendance: </strong> <%= if @event.allow_remote then "Yes" else "No" end %> </p>
+
     <p><strong>Room Name:</strong> <%= @event.room.name.titleize %></p>
     <p><strong>Event created by:</strong></p>
     <p><%= @event.user.full_name.titleize %></p>

--- a/db/migrate/20160426172525_allow_remote_events.rb
+++ b/db/migrate/20160426172525_allow_remote_events.rb
@@ -1,0 +1,5 @@
+class AllowRemoteEvents < ActiveRecord::Migration
+  def change
+    add_column :events, :allow_remote, :bool, default: false
+  end
+end


### PR DESCRIPTION
remote_attendance can now be set at event create. Invites have a custom validator that makes sure remotely attended invites can not be set to events unless the event allows remote attendance.
# YOLO
